### PR TITLE
implemented fqueue generators and exposed them on mli file

### DIFF
--- a/core/src/fdeque.ml
+++ b/core/src/fdeque.ml
@@ -151,6 +151,37 @@ let dequeue_exn t side =
 
 let rev t = { t with front = t.back; back = t.front }
 
+let gen_with_length length quickcheck_generator = 
+  let open Quickcheck.Let_syntax in 
+  let%bind full_list = List.gen_with_length length quickcheck_generator in 
+  let front, back = List.split_n full_list (length/2) in 
+  return {front; back; length};
+;;
+
+let gen_non_empty quickcheck_generator =
+  let open Quickcheck.Let_syntax in 
+  let%bind length = Int.gen_uniform_incl 0 Int.max_value in 
+  gen_with_length length quickcheck_generator
+;;
+
+let gen_filtered seq =
+  let open Quickcheck.Let_syntax in 
+  let full_list = List.concat [seq.front; seq.back] in 
+  let%bind gen_filtered = List.gen_filtered full_list in 
+  let length = List.length full_list in 
+  let front, back = List.split_n gen_filtered (length/2) in 
+  return {front; back; length}
+;;
+
+let gen_permutations seq = 
+  let open Quickcheck.Let_syntax in 
+  let full_list = List.concat [seq.front; seq.back] in 
+  let%bind result = List.gen_permutations full_list in 
+  let length = List.length result in 
+  let front, back = List.split_n result (length/2) in 
+  return {front; back; length}
+;;
+
 module Arbitrary_order = struct
   let is_empty = is_empty
   let length = length

--- a/core/src/fdeque.mli
+++ b/core/src/fdeque.mli
@@ -64,6 +64,14 @@ val of_list : 'a list -> 'a t
     Complexity: worst-case O(1). *)
 val rev : 'a t -> 'a t
 
+val gen_with_length : int -> 'a Quickcheck.Generator.t -> 'a t Quickcheck.Generator.t
+
+val gen_non_empty : 'a Quickcheck.Generator.t -> 'a t Quickcheck.Generator.t
+
+val gen_filtered: 'a t -> 'a t Quickcheck.Generator.t
+
+val gen_permutations: 'a t -> 'a t Quickcheck.Generator.t 
+
 (** [enqueue t side x] produces [t] updated with [x] added to its [side].
 
     Complexity: worst-case O(1). *)

--- a/core/src/fqueue.ml
+++ b/core/src/fqueue.ml
@@ -9,7 +9,10 @@ let dequeue = dequeue_front
 let drop_exn = drop_front_exn
 let to_sequence = Front_to_back.to_sequence
 let of_sequence = Front_to_back.of_sequence
-
+let gen_with_length = Fdeque.gen_with_length
+let gen_non_empty = Fdeque.gen_non_empty 
+let gen_filtered = Fdeque.gen_filtered 
+let gen_permutations = Fdeque.gen_permutations
 (* Deprecated aliases *)
 let top = peek
 let top_exn = peek_exn

--- a/core/src/fqueue.mli
+++ b/core/src/fqueue.mli
@@ -30,6 +30,14 @@ val top_exn : 'a t -> 'a [@@deprecated "[since 2019-11] Use [peek_exn] instead."
     O(1). *)
 val peek : 'a t -> 'a option
 
+val gen_with_length : int -> 'a Quickcheck.Generator.t -> 'a t Quickcheck.Generator.t
+
+val gen_non_empty : 'a Quickcheck.Generator.t -> 'a t Quickcheck.Generator.t
+
+val gen_filtered: 'a t -> 'a t Quickcheck.Generator.t
+
+val gen_permutations: 'a t -> 'a t Quickcheck.Generator.t 
+
 val top : 'a t -> 'a option [@@deprecated "[since 2019-11] Use [peek] instead."]
 
 (** [dequeue_exn t] removes and returns the front of [t], raising [Empty] if [t] is empty.


### PR DESCRIPTION
under the hood, fqueue is just an fdequeue with more restrictions, so I implemented generators that are similar to list generators, which are the following:

gen_with_length generates an fdeque of a given length
gen_non_empty generatres a fdeque of a random length; the fdeque could be empty and it picks the length from [0, Int.max_value] uniformly
gen_filtered generates lists where some items are randomly dropped from the given list
gen_permutations generates permutations of a given list
These were then exposed in the fqueue mli file since it's internally the same as an fdeque